### PR TITLE
Allow more DataDeps versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoogleDrive"
 uuid = "91feb7a0-3508-11ea-1e8e-afea2c1c9a19"
 authors = ["tejasvaidhyadev <iamtejasvaidhya@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -14,7 +14,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 [compat]
 julia = "1"
 HTTP = "0.8.1"
-DataDeps = "0.5"
+DataDeps = "0.5, 0.6, 0.7"
 Documenter = "0.24"
 
 


### PR DESCRIPTION
Should close https://github.com/JuliaText/Embeddings.jl/issues/33
I have also incremented version number so a release can be tagged soon after merging